### PR TITLE
Use entry-wise batchnorm for flat data

### DIFF
--- a/1_train/512_sqr/ExaGAN.py
+++ b/1_train/512_sqr/ExaGAN.py
@@ -139,7 +139,10 @@ class CosmoGAN(lbann.modules.Module):
         '''
         Build the Generator
         '''
-        x = lbann.Relu(lbann.BatchNormalization(self.g_fc1(z),decay=0.9,scale_init=1.0,epsilon=1e-5))
+        x = self.g_fc1(z)
+        x = lbann.EntrywiseBatchNormalization(x, decay=0.9, epsilon=1e-5)
+        x = lbann.EntrywiseScaleBias(x)
+        x = lbann.Relu(x)
         dims='512 32 32'
         x = lbann.Reshape(x, dims=dims) #channel first
         
@@ -201,3 +204,4 @@ class CosmoGAN(lbann.modules.Module):
 #         a=0.5/np.log(300)
 #         b=0.5-a*np.log(50)
 #         return np.exp((y-b)/a)
+

--- a/1_train/main_code/ExaGAN.py
+++ b/1_train/main_code/ExaGAN.py
@@ -141,7 +141,10 @@ class CosmoGAN(lbann.modules.Module):
         '''
         Build the Generator
         '''
-        x = lbann.Relu(lbann.BatchNormalization(self.g_fc1(z),decay=0.9,scale_init=1.0,epsilon=1e-5))
+        x = self.g_fc1(z)
+        x = lbann.EntrywiseBatchNormalization(x, decay=0.9, epsilon=1e-5)
+        x = lbann.EntrywiseScaleBias(x)
+        x = lbann.Relu(x)
         dims='512 8 8'
         x = lbann.Reshape(x, dims=dims) #channel first
         
@@ -203,3 +206,4 @@ class CosmoGAN(lbann.modules.Module):
 #         a=0.5/np.log(300)
 #         b=0.5-a*np.log(50)
 #         return np.exp((y-b)/a)
+


### PR DESCRIPTION
I've narrowed down the run-time error in @vmos1's 512x512 model to an invalid CUDA kernel invocation in batchnorm. A fix is in the works.

Fortunately, it's easy to workaround the bug by replacing a batchnorm layer in the generator with entry-wise batchnorm. Entry-wise batchnorm is optimized for flat data while standard batchnorm is optimized for image data. One caveat is that entry-wise batchnorm always computes global statistics, so the inter-process communication might hurt performance. That said, local statistics is problematic on flat data since the number of statistics samples is so small it could lead to wonky results.